### PR TITLE
fix(create-extend-error): handle undefined error#stack

### DIFF
--- a/src/create-extend-error.js
+++ b/src/create-extend-error.js
@@ -12,7 +12,7 @@ function createExtendError (ErrorClass, classProps) {
     const errorProps = isString(props) ? { message: props } : props
     addErrorProps(error, classProps, errorProps)
 
-    error.stack = cleanStack(error.stack)
+    error.stack = typeof error.stack === 'string' ? cleanStack(error.stack) : undefined
     return error
   }
 


### PR DESCRIPTION
## Context
Most of the non-V8 powered browsers haven't implemented Error#captureStackTrace API due to which stack trace generation fails in browsers like Safari (Mac, iOS). This results in error#stack being undefined in such browsers.

Whoops uses clean-stack v3.0.0 to format the stack trace, wherein clean-stack fails to handle undefined `stack` parameter which leads to a TypeError being thrown. To be precise, we have seen the following error on iOS Safari - `undefined is not an object (evaluating 'stack.replace')` which originates from https://github.com/sindresorhus/clean-stack/blob/v3.0.0/index.js#L12

Clean-stack didn't support and handle an `undefined` value for the `stack` parameter until [v4.1.0](https://github.com/sindresorhus/clean-stack/releases/tag/v4.1.0) wherein it has started returning `undefined` if `stack` is empty.

## Changes
Handled the above mentioned case by ensuring cleanstack isn't called unless stack is of type `string`. 

Note: We could've simply upgraded the version of clean-stack but it has started shipping the dist code as ESM which might not be compatible with the build system used by the users of whoops. 